### PR TITLE
New version 1.08 for Django 1.4 available on vim.org

### DIFF
--- a/syntax/django.vim
+++ b/syntax/django.vim
@@ -21,7 +21,7 @@ syn match djangoError "%}\|}}\|#}"
 syn keyword djangoStatement contained autoescape csrf_token empty
 " FIXME ==, !=, <, >, <=, and >= should be djangoStatements:
 " syn keyword djangoStatement contained == != < > <= >=
-syn keyword djangoStatement contained and as block endblock by cycle debug else
+syn keyword djangoStatement contained and as block endblock by cycle debug else elif
 syn keyword djangoStatement contained extends filter endfilter firstof for
 syn keyword djangoStatement contained endfor if endif ifchanged endifchanged
 syn keyword djangoStatement contained ifequal endifequal ifnotequal
@@ -45,7 +45,7 @@ syn keyword djangoFilter contained linebreaks linebreaksbr linenumbers ljust
 syn keyword djangoFilter contained lower make_list phone2numeric pluralize
 syn keyword djangoFilter contained pprint random removetags rjust slice slugify
 syn keyword djangoFilter contained safe safeseq stringformat striptags
-syn keyword djangoFilter contained time timesince timeuntil title
+syn keyword djangoFilter contained time timesince timeuntil title truncatechars
 syn keyword djangoFilter contained truncatewords truncatewords_html unordered_list upper urlencode
 syn keyword djangoFilter contained urlize urlizetrunc wordcount wordwrap yesno
 


### PR DESCRIPTION
"Highlights the elif tag and truncatechars filter, both from Django 1.4.
Thanks to iynaix (Lin Xianyi)."

see http://www.vim.org/scripts/script.php?script_id=1487
